### PR TITLE
Cache only HTTP or HTTPS requests using GET verb

### DIFF
--- a/service-worker/index.js
+++ b/service-worker/index.js
@@ -3,6 +3,11 @@ import { addFetchListener, PROJECT_REVISION } from 'ember-service-worker/service
 const CACHE_KEY_PREFIX = 'esw-cache-first-';
 const CACHE_NAME = `${CACHE_KEY_PREFIX}${PROJECT_REVISION}`;
 
+function isCacheable(request) {
+  let httpRegex = /https?/;
+  return request.method === 'GET' && httpRegex.test(request.url);
+}
+
 addFetchListener(function(event) {
   if (event.request.method !== 'GET') { return Promise.resolve(undefined); }
 
@@ -12,7 +17,10 @@ addFetchListener(function(event) {
 
       return fetch(event.request)
         .then(function(response) {
-          cache.put(event.request, response.clone());
+          if (isCacheable(event.request)) {
+            cache.put(event.request, response.clone());
+          }
+
           return response;
         });
     });


### PR DESCRIPTION
This PR solves #6 by only caching the requests made using HTTP or HTTPS and the GET verb since the cache API only accepts to cache those types of requests, see https://developer.mozilla.org/en-US/docs/Web/API/Cache